### PR TITLE
Added auto-magical kind detection and tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metatron (0.2.0)
+    metatron (0.2.1)
       json (~> 2.6)
       puma (~> 6.3)
       sinatra (~> 2.2)

--- a/lib/metatron/template.rb
+++ b/lib/metatron/template.rb
@@ -18,7 +18,7 @@ module Metatron
       @name = name
       @label_namespace = self.class.label_namespace
       @api_version = "v1"
-      @kind = self.class.name.split("::").last
+      @kind = find_kind
       run_initializers
     end
 
@@ -37,6 +37,16 @@ module Metatron
 
     def run_initializers
       self.class.initializers.each { |initializer| send(initializer.to_sym) }
+    end
+
+    def find_kind
+      return self.class.name.split("::").last if metatron_template?
+
+      self.class.ancestors.find { |klass| metatron_template?(klass) }.name.split("::").last
+    end
+
+    def metatron_template?(klass = self)
+      klass.name.include?("Metatron::Templates") && !klass.name.include?("Concerns")
     end
   end
 end

--- a/lib/metatron/version.rb
+++ b/lib/metatron/version.rb
@@ -4,6 +4,6 @@ module Metatron
   VERSION = [
     0, # major
     2, # minor
-    0  # patch
+    1  # patch
   ].join(".")
 end

--- a/spec/metatron/template_spec.rb
+++ b/spec/metatron/template_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "metatron"
+
+RSpec.describe Metatron::Template do
+  describe "for basic template behaviours" do
+    it "uses the classe's name if it is a template" do
+      actual_kind = Metatron::Templates::ConfigMap.new("test").render[:kind]
+      expect(actual_kind).to eq("ConfigMap")
+    end
+
+    it "uses the closest ancestor's name if it inherits a template" do
+      actual_kind = FakeConfigMap.new("test", { "foo" => "bar" }).render[:kind]
+      expect(actual_kind).to eq("ConfigMap")
+    end
+
+    it "uses the closest template's name even if it includes metatron concerns" do
+      actual_kind = FakeConfigMapWithInclude.new("test", { "foo" => "bar" }).render[:kind]
+      expect(actual_kind).to eq("ConfigMap")
+    end
+  end
+end
+
+class FakeConfigMapWithInclude < Metatron::Templates::ConfigMap
+  include Metatron::Templates::Concerns::Namespaced
+end
+
+class FakeConfigMap < Metatron::Templates::ConfigMap; end


### PR DESCRIPTION
This PR enables Metatron to auto-magically determine a resource's kind if it is a subclass of a template. 
In the event that someone defines a resource this way:
```RUBY
class MyConfigMap < Metatron::Templates::ConfigMap
  def initialize
    super("my-config-map", { foo: :bar })
  end
end
```
The kind would then be `kind: MyConfigMap` when it really should be `kind: Secret`.

This PR dynamically gets the closest template's class name and uses it as the kind when it renders.