### PR TITLE
Unified pod approach to fix pod templates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metatron (0.2.2)
+    metatron (0.2.3)
       json (~> 2.6)
       puma (~> 6.3)
       sinatra (~> 2.2)

--- a/lib/metatron/templates/concerns/pod_producer.rb
+++ b/lib/metatron/templates/concerns/pod_producer.rb
@@ -5,36 +5,79 @@ module Metatron
     module Concerns
       # A mixin to assist with templating Kubernetes resources that create Pods
       module PodProducer
-        def self.included(base)
+        def self.included(base) # rubocop:disable Metrics/MethodLength
           # base.extend ClassMethods
           base.class_eval do
-            attr_accessor :additional_labels, :additional_pod_labels,
-                          :security_context, :volumes, :containers, :init_containers,
-                          :affinity, :termination_grace_period_seconds,
-                          :tolerations, :pod_annotations, :persistent_volume_claims
+            attr_accessor :active_deadline_seconds, :additional_labels, :additional_pod_labels,
+                          :affinity, :automount_service_account_token, :containers,
+                          :dns_policy, :enable_service_links, :hostname, :host_ipc, :host_network,
+                          :host_pid, :image_pull_secrets, :init_containers, :node_selector,
+                          :node_name, :persistent_volume_claims, :pod_annotations, :restart_policy,
+                          :scheduler_name, :security_context, :service_account,
+                          :service_account_name, :share_process_namespace, :subdomain,
+                          :termination_grace_period_seconds, :tolerations, :volumes
 
             initializer :pod_producer_initialize
 
+            alias_method :activeDeadlineSeconds, :active_deadline_seconds
+            alias_method :automountServiceAccountToken, :automount_service_account_token
+            alias_method :dnsPolicy, :dns_policy
+            alias_method :enableServiceLinks, :enable_service_links
+            alias_method :hostIPC, :host_ipc
+            alias_method :hostNetwork, :host_network
+            alias_method :hostPID, :host_pid
+            alias_method :nodeSelector, :node_selector
+            alias_method :nodeName, :node_name
+            alias_method :restartPolicy, :restart_policy
+            alias_method :schedulerName, :scheduler_name
             alias_method :securityContext, :security_context
+            alias_method :serviceAccount, :service_account
+            alias_method :serviceAccountName, :service_account_name
+            alias_method :shareProcessNamespace, :share_process_namespace
             alias_method :terminationGracePeriodSeconds, :termination_grace_period_seconds
           end
         end
 
         def pod_producer_initialize
-          @affinity = {}
-          @volumes = []
-          @security_context = {}
-          @containers = []
-          @init_containers = []
           @additional_labels = {}
           @additional_pod_labels = {}
+          @affinity = {}
+          @containers = []
+          @enable_service_links = nil
+          @image_pull_secrets = []
+          @init_containers = []
+          @node_selector = {}
+          @persistent_volume_claims = []
           @pod_annotations = {}
+          @restart_policy = nil
+          @security_context = {}
           @termination_grace_period_seconds = nil
           @tolerations = []
-          @persistent_volume_claims = []
+          @volumes = []
         end
 
         def formatted_affinity = affinity && !affinity.empty? ? { affinity: } : {}
+        def formatted_containers = { containers: containers.map(&:render) }
+
+        def formatted_image_pull_secrets
+          if image_pull_secrets&.any?
+            { imagePullSecrets: image_pull_secrets.map { _1.is_a?(String) ? { name: _1 } : _1 } }
+          else
+            {}
+          end
+        end
+
+        def formatted_init_containers
+          if init_containers&.any?
+            { initContainers: init_containers.map(&:render) }
+          else
+            {}
+          end
+        end
+
+        def formatted_node_selector
+          node_selector && !node_selector.empty? ? { nodeSelector: } : {}
+        end
 
         def formatted_pod_annotations
           pod_annotations && !pod_annotations.empty? ? { annotations: pod_annotations } : {}
@@ -57,6 +100,55 @@ module Metatron
           else
             {}
           end
+        end
+
+        def pod_metadata
+          {
+            metadata: {
+              labels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
+            }.merge(formatted_pod_annotations)
+          }
+        end
+
+        # rubocop:disable Metrics/AbcSize
+        # rubocop:disable Metrics/MethodLength
+        def pod_spec
+          {
+            spec: {
+              activeDeadlineSeconds:,
+              automountServiceAccountToken:,
+              dnsPolicy:,
+              enableServiceLinks:,
+              hostIPC:,
+              hostNetwork:,
+              hostPID:,
+              hostname:,
+              nodeName:,
+              restartPolicy:,
+              schedulerName:,
+              serviceAccount:,
+              serviceAccountName:,
+              shareProcessNamespace:,
+              subdomain:,
+              terminationGracePeriodSeconds:
+            }.merge(formatted_volumes)
+              .merge(formatted_affinity)
+              .merge(formatted_tolerations)
+              .merge(formatted_security_context)
+              .merge(formatted_containers)
+              .merge(formatted_init_containers)
+              .merge(formatted_image_pull_secrets)
+              .merge(formatted_node_selector)
+              .compact
+          }.compact
+        end
+        # rubocop:enable Metrics/AbcSize
+        # rubocop:enable Metrics/MethodLength
+
+        def pod_template
+          {
+            template: {}.merge(pod_metadata).merge(pod_spec).compact
+          }
         end
       end
     end

--- a/lib/metatron/templates/cron_job.rb
+++ b/lib/metatron/templates/cron_job.rb
@@ -10,19 +10,10 @@ module Metatron
 
       attr_accessor :schedule, :suspend, :concurrency_policy, :starting_deadline_seconds,
                     :successful_jobs_history_limit, :failed_jobs_history_limit,
-                    :automount_service_account_token, :backoff_limit, :active_deadline_seconds,
-                    :dns_policy, :restart_policy,
-                    :scheduler_name, :service_account, :service_account_name
+                    :backoff_limit
 
-      alias automountServiceAccountToken automount_service_account_token
       alias backoffLimit backoff_limit
-      alias activeDeadlineSeconds active_deadline_seconds
       alias concurrencyPolicy concurrency_policy
-      alias dnsPolicy dns_policy
-      alias restartPolicy restart_policy
-      alias schedulerName scheduler_name
-      alias serviceAccount service_account
-      alias serviceAccountName service_account_name
       alias startingDeadlineSeconds starting_deadline_seconds
       alias successfulJobsHistoryLimit successful_jobs_history_limit
       alias failedJobsHistoryLimit failed_jobs_history_limit
@@ -31,11 +22,9 @@ module Metatron
         super(name)
         @schedule = schedule
         @api_version = "batch/v1"
-        @restart_policy = "OnFailure"
       end
 
       # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       def render
         {
           apiVersion:,
@@ -54,30 +43,13 @@ module Metatron
             jobTemplate: {
               spec: {
                 activeDeadlineSeconds:,
-                backoffLimit:,
-                template: {
-                  spec: {
-                    automountServiceAccountToken:,
-                    terminationGracePeriodSeconds:,
-                    dnsPolicy:,
-                    restartPolicy:,
-                    schedulerName:,
-                    serviceAccount:,
-                    serviceAccountName:,
-                    containers: containers.map(&:render),
-                    init_containers: init_containers.any? ? init_containers.map(&:render) : nil
-                  }.merge(formatted_volumes)
-                    .merge(formatted_security_context)
-                    .compact
-                }.compact
-              }.compact
-            }.merge(formatted_tolerations)
-              .compact
+                backoffLimit:
+              }.merge(pod_template).compact
+            }.merge(formatted_tolerations).compact
           }.compact
         }
       end
       # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/metatron/templates/daemon_set.rb
+++ b/lib/metatron/templates/daemon_set.rb
@@ -15,8 +15,6 @@ module Metatron
         @api_version = "apps/v1"
       end
 
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       def render
         {
           apiVersion:,
@@ -28,25 +26,10 @@ module Metatron
           spec: {
             selector: {
               matchLabels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
-            },
-            template: {
-              metadata: {
-                labels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
-              }.merge(formatted_pod_annotations),
-              spec: {
-                terminationGracePeriodSeconds:,
-                containers: containers.map(&:render),
-                init_containers: init_containers.any? ? init_containers.map(&:render) : nil
-              }.merge(formatted_volumes)
-                .merge(formatted_security_context)
-                .merge(formatted_tolerations)
-                .compact
             }
-          }
+          }.merge(pod_template)
         }
       end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/metatron/templates/deployment.rb
+++ b/lib/metatron/templates/deployment.rb
@@ -16,8 +16,6 @@ module Metatron
         @replicas = replicas
       end
 
-      # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/AbcSize
       def render
         {
           apiVersion:,
@@ -31,25 +29,10 @@ module Metatron
             strategy: { type: "RollingUpdate", rollingUpdate: { maxSurge: 2, maxUnavailable: 0 } },
             selector: {
               matchLabels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
-            },
-            template: {
-              metadata: {
-                labels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
-              }.merge(formatted_pod_annotations).merge(formatted_namespace),
-              spec: {
-                terminationGracePeriodSeconds:,
-                containers: containers.map(&:render),
-                init_containers: init_containers.any? ? init_containers.map(&:render) : nil
-              }.merge(formatted_volumes)
-                .merge(formatted_security_context)
-                .merge(formatted_tolerations)
-                .compact
             }
-          }
+          }.merge(pod_template)
         }
       end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/metatron/templates/job.rb
+++ b/lib/metatron/templates/job.rb
@@ -23,8 +23,6 @@ module Metatron
         @api_version = "batch/v1"
       end
 
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       def render
         {
           apiVersion:,
@@ -40,23 +38,10 @@ module Metatron
             completions:,
             parallelism:,
             podFailurePolicy:,
-            ttlSecondsAfterFinished:,
-            template: {
-              spec: {
-                terminationGracePeriodSeconds:,
-                restartPolicy:,
-                containers: containers.map(&:render),
-                init_containers: init_containers.any? ? init_containers.map(&:render) : nil
-              }.merge(formatted_volumes)
-                .merge(formatted_security_context)
-                .merge(formatted_tolerations)
-                .compact
-            }.compact
-          }.compact
+            ttlSecondsAfterFinished:
+          }.merge(pod_template).compact
         }
       end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/metatron/templates/pod.rb
+++ b/lib/metatron/templates/pod.rb
@@ -8,7 +8,6 @@ module Metatron
       include Concerns::PodProducer
       include Concerns::Namespaced
 
-      # rubocop:disable Metrics/AbcSize
       def render
         {
           apiVersion:,
@@ -16,18 +15,9 @@ module Metatron
           metadata: {
             labels: { "#{label_namespace}/name": name }.merge(additional_labels),
             name:
-          }.merge(formatted_annotations).merge(formatted_namespace),
-          spec: {
-            terminationGracePeriodSeconds:,
-            containers: containers.map(&:render),
-            init_containers: init_containers.any? ? init_containers.map(&:render) : nil
-          }.merge(formatted_volumes)
-            .merge(formatted_security_context)
-            .merge(formatted_tolerations)
-            .compact
-        }
+          }.merge(formatted_annotations).merge(formatted_namespace)
+        }.merge(pod_spec)
       end
-      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/lib/metatron/templates/replica_set.rb
+++ b/lib/metatron/templates/replica_set.rb
@@ -16,8 +16,6 @@ module Metatron
         @replicas = replicas
       end
 
-      # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/AbcSize
       def render
         {
           apiVersion:,
@@ -30,25 +28,10 @@ module Metatron
             replicas:,
             selector: {
               matchLabels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
-            },
-            template: {
-              metadata: {
-                labels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
-              }.merge(formatted_pod_annotations),
-              spec: {
-                terminationGracePeriodSeconds:,
-                containers: containers.map(&:render),
-                init_containers: init_containers.any? ? init_containers.map(&:render) : nil
-              }.merge(formatted_volumes)
-                .merge(formatted_security_context)
-                .merge(formatted_tolerations)
-                .compact
             }
-          }
+          }.merge(pod_template)
         }
       end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/metatron/templates/stateful_set.rb
+++ b/lib/metatron/templates/stateful_set.rb
@@ -8,14 +8,13 @@ module Metatron
       include Concerns::PodProducer
       include Concerns::Namespaced
 
-      attr_accessor :replicas, :service_name, :pod_management_policy, :enable_service_links
+      attr_accessor :replicas, :service_name, :pod_management_policy
 
       def initialize(name, replicas: 1)
         super(name)
         @replicas = replicas
         @api_version = "apps/v1"
         @pod_management_policy = "OrderedReady"
-        @enable_service_links = true
         @service_name = name
       end
 
@@ -23,8 +22,6 @@ module Metatron
       alias podManagementPolicy pod_management_policy
       alias serviceName service_name
 
-      # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/AbcSize
       def render
         {
           apiVersion:,
@@ -36,29 +33,13 @@ module Metatron
           spec: {
             replicas:,
             serviceName:,
-            enableServiceLinks:,
             strategy: { type: "RollingUpdate", rollingUpdate: { maxSurge: 2, maxUnavailable: 0 } },
             selector: {
               matchLabels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
-            },
-            template: {
-              metadata: {
-                labels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
-              }.merge(formatted_pod_annotations),
-              spec: {
-                terminationGracePeriodSeconds:,
-                containers: containers.map(&:render),
-                init_containers: init_containers.any? ? init_containers.map(&:render) : nil
-              }.merge(formatted_volumes)
-                .merge(formatted_affinity)
-                .merge(formatted_tolerations)
-                .compact
             }
-          }
+          }.merge(pod_template)
         }.merge(volume_claim_templates)
       end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/lib/metatron/version.rb
+++ b/lib/metatron/version.rb
@@ -4,6 +4,6 @@ module Metatron
   VERSION = [
     0, # major
     2, # minor
-    2  # patch
+    3  # patch
   ].join(".")
 end

--- a/spec/metatron/templates/cron_job_spec.rb
+++ b/spec/metatron/templates/cron_job_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Metatron::Templates::CronJob do
           jobTemplate: {
             spec: {
               template: {
+                metadata: { labels: { "metatron.therubyist.org/name": "hello" } },
                 spec: {
-                  restartPolicy: "OnFailure",
                   containers: [
                     {
                       image: "gcr.io/google_containers/pause",
@@ -77,8 +77,8 @@ RSpec.describe Metatron::Templates::CronJob do
           jobTemplate: {
             spec: {
               template: {
+                metadata: { labels: { "metatron.therubyist.org/name": "hello" } },
                 spec: {
-                  restartPolicy: "OnFailure",
                   containers: [
                     {
                       image: "gcr.io/google_containers/pause",

--- a/spec/metatron/templates/job_spec.rb
+++ b/spec/metatron/templates/job_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Metatron::Templates::Job do
         metadata: { labels: { "metatron.therubyist.org/name": "hello" }, name: "hello" },
         spec: {
           template: {
+            metadata: { labels: { "metatron.therubyist.org/name": "hello" } },
             spec: {
               containers: [
                 {


### PR DESCRIPTION
Moved pod templates to the pod producer using a unified approach, which brings all pod features available in Metatron to all pod producers. Fixes an issue related to `initContainers`  as well.