### PR TITLE
Adding namespace field for deployments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metatron (0.2.3)
+    metatron (0.2.4)
       json (~> 2.6)
       puma (~> 6.3)
       sinatra (~> 2.2)

--- a/lib/metatron/templates/deployment.rb
+++ b/lib/metatron/templates/deployment.rb
@@ -23,7 +23,7 @@ module Metatron
           metadata: {
             name:,
             labels: { "#{label_namespace}/name": name }.merge(additional_labels)
-          }.merge(formatted_annotations),
+          }.merge(formatted_annotations).merge(formatted_namespace),
           spec: {
             replicas:,
             strategy: { type: "RollingUpdate", rollingUpdate: { maxSurge: 2, maxUnavailable: 0 } },

--- a/lib/metatron/version.rb
+++ b/lib/metatron/version.rb
@@ -4,6 +4,6 @@ module Metatron
   VERSION = [
     0, # major
     2, # minor
-    3  # patch
+    4  # patch
   ].join(".")
 end


### PR DESCRIPTION
It was found that Deployments, although they included the namespaced module, didn't use the `formatted_namespace` function. 

This PR ensures that deployments can be namespaced.