### PR TITLE
Changing `StatefulSet.spec.stratery` to `updateStrategy`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metatron (0.2.3)
+    metatron (0.2.5)
       json (~> 2.6)
       puma (~> 6.3)
       sinatra (~> 2.2)

--- a/lib/metatron/templates/stateful_set.rb
+++ b/lib/metatron/templates/stateful_set.rb
@@ -33,7 +33,8 @@ module Metatron
           spec: {
             replicas:,
             serviceName:,
-            strategy: { type: "RollingUpdate", rollingUpdate: { maxSurge: 2, maxUnavailable: 0 } },
+            updateStrategy: { type: "RollingUpdate",
+                              rollingUpdate: { maxSurge: 2, maxUnavailable: 0 } },
             selector: {
               matchLabels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
             }

--- a/lib/metatron/templates/stateful_set.rb
+++ b/lib/metatron/templates/stateful_set.rb
@@ -38,8 +38,8 @@ module Metatron
             selector: {
               matchLabels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
             }
-          }.merge(pod_template)
-        }.merge(volume_claim_templates)
+          }.merge(pod_template).merge(volume_claim_templates)
+        }
       end
     end
   end

--- a/lib/metatron/version.rb
+++ b/lib/metatron/version.rb
@@ -4,6 +4,6 @@ module Metatron
   VERSION = [
     0, # major
     2, # minor
-    3  # patch
+    5  # patch
   ].join(".")
 end

--- a/spec/metatron/templates/stateful_set_spec.rb
+++ b/spec/metatron/templates/stateful_set_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe Metatron::Templates::StatefulSet do
           replicas: 1,
           selector: { matchLabels: { "metatron.therubyist.org/name": "test" } },
           serviceName: "test",
-          strategy: { rollingUpdate: { maxSurge: 2, maxUnavailable: 0 }, type: "RollingUpdate" },
+          updateStrategy: {
+            rollingUpdate: { maxSurge: 2, maxUnavailable: 0 },
+            type: "RollingUpdate"
+          },
           template: {
             metadata: { labels: { "metatron.therubyist.org/name": "test" } },
             spec: {
@@ -91,7 +94,10 @@ RSpec.describe Metatron::Templates::StatefulSet do
           replicas: 5,
           selector: { matchLabels: { "metatron.therubyist.org/name": "test", foo: "bar" } },
           serviceName: "a-test",
-          strategy: { rollingUpdate: { maxSurge: 2, maxUnavailable: 0 }, type: "RollingUpdate" },
+          updateStrategy: {
+            rollingUpdate: { maxSurge: 2, maxUnavailable: 0 },
+            type: "RollingUpdate"
+          },
           template: {
             metadata: { labels: { "metatron.therubyist.org/name": "test", foo: "bar" } },
             spec: {

--- a/spec/metatron/templates/stateful_set_spec.rb
+++ b/spec/metatron/templates/stateful_set_spec.rb
@@ -128,27 +128,27 @@ RSpec.describe Metatron::Templates::StatefulSet do
               terminationGracePeriodSeconds: 10,
               enableServiceLinks: false
             }
-          }
-        },
-        volumeClaimTemplates: [
-          {
-            apiVersion: "v1",
-            kind: "PersistentVolumeClaim",
-            metadata: {
-              name: "test",
-              labels: { "metatron.therubyist.org/name": "test" }
-            },
-            spec: {
-              accessModes: ["ReadWriteOnce"],
-              storageClassName: "test",
-              resources: {
-                requests: {
-                  storage: "1Gi"
+          },
+          volumeClaimTemplates: [
+            {
+              apiVersion: "v1",
+              kind: "PersistentVolumeClaim",
+              metadata: {
+                name: "test",
+                labels: { "metatron.therubyist.org/name": "test" }
+              },
+              spec: {
+                accessModes: ["ReadWriteOnce"],
+                storageClassName: "test",
+                resources: {
+                  requests: {
+                    storage: "1Gi"
+                  }
                 }
               }
             }
-          }
-        ]
+          ]
+        }
       }
     end
 


### PR DESCRIPTION
The StatefulSet template seemed to provide a `strategy`. While looking at the docs, it seems like this property should be named `updateStrategy` ([source](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies)).

Moreover, It seems that `volumeClaimTemplates` should be under `spec` and not under the object's root. ([source](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#volume-claim-templates))