### PR TITLE
Add ETag support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metatron (0.3.0)
+    metatron (0.3.1)
       json (~> 2.6)
       puma (~> 6.3)
       sinatra (~> 2.2)

--- a/lib/metatron/sync_controller.rb
+++ b/lib/metatron/sync_controller.rb
@@ -9,9 +9,21 @@ module Metatron
     end
 
     post "/" do
+      # TODO: move this to Sinatra's `etag` helper when Metacontroller is RFC compliant
+      if (provided_etag = calculate_etag) &&
+         (match_header = request.env["HTTP_IF_NONE_MATCH"]) &&
+         match_header.split(/,\s?/).include?("\"#{provided_etag}\"")
+        halt 304
+      end
+
+      # If the etag is available, use it, otherwise proceed with the sync
+      headers "ETag" => "\"#{provided_etag}\"" if provided_etag
       data = sync
       data[:children] = data[:children]&.map { |c| c.respond_to?(:render) ? c.render : c }
       halt(data.to_json)
     end
+
+    def calculate_etag = nil
+    def sync = raise NotImplementedError
   end
 end

--- a/lib/metatron/version.rb
+++ b/lib/metatron/version.rb
@@ -4,6 +4,6 @@ module Metatron
   VERSION = [
     0, # major
     3, # minor
-    0  # patch
+    1  # patch
   ].join(".")
 end

--- a/spec/metatron/sync_controller_spec.rb
+++ b/spec/metatron/sync_controller_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rack/test"
+
+class TestSyncController < Metatron::SyncController
+  def sync = { status: {}, children: [] }
+end
+
+class TestSyncControllerWithEtags < Metatron::SyncController
+  def calculate_etag = "abcd1234"
+  def sync = { status: {}, children: [] }
+end
+
+RSpec.describe Metatron::SyncController do
+  include Rack::Test::Methods
+
+  context "when ETag support is NOT enabled" do
+    def app = TestSyncController
+
+    it "returns a 200 OK for initial sync requests" do
+      post "/", {}, "HTTP_ACCEPT" => "application/json", "Content-Type" => "application/json"
+      expect(last_response.status).to eq(200)
+    end
+
+    it "returns the expected data for initial sync requests" do
+      post "/", {}, "HTTP_ACCEPT" => "application/json", "Content-Type" => "application/json"
+      expect(last_response.body).to eq({ status: {}, children: [] }.to_json)
+    end
+
+    it "does not provide an ETag header for initial sync requests" do
+      post "/", {}, "HTTP_ACCEPT" => "application/json", "Content-Type" => "application/json"
+      expect(last_response.headers.keys).not_to include("ETag")
+    end
+
+    it "returns a 200 for standard sync requests" do # rubocop:disable RSpec/ExampleLength
+      post(
+        "/",
+        {},
+        {
+          "HTTP_ACCEPT" => "application/json",
+          "HTTP_IF_NONE_MATCH" => "\"abcd1234\"", # This should be ignored
+          "CONTENT_TYPE" => "application/json"
+        }
+      )
+      expect(last_response.status).to eq(200)
+    end
+
+    it "provides the expected data for standard sync requests" do # rubocop:disable RSpec/ExampleLength
+      post(
+        "/",
+        {},
+        {
+          "HTTP_ACCEPT" => "application/json",
+          "HTTP_IF_NONE_MATCH" => "\"abcd1234\"", # This should be ignored
+          "CONTENT_TYPE" => "application/json"
+        }
+      )
+      expect(last_response.body).to eq({ status: {}, children: [] }.to_json)
+    end
+  end
+
+  context "when ETag support is enabled" do
+    def app = TestSyncControllerWithEtags
+
+    it "returns a 200 OK for initial sync requests" do
+      post "/", {}, "HTTP_ACCEPT" => "application/json", "Content-Type" => "application/json"
+      expect(last_response.status).to eq(200)
+    end
+
+    it "returns the expected data for initial sync requests" do
+      post "/", {}, "HTTP_ACCEPT" => "application/json", "Content-Type" => "application/json"
+      expect(last_response.body).to eq({ status: {}, children: [] }.to_json)
+    end
+
+    it "returns the expected ETag header for initial sync requests" do
+      post "/", {}, "HTTP_ACCEPT" => "application/json", "Content-Type" => "application/json"
+      expect(last_response.headers).to include("ETag" => "\"abcd1234\"")
+    end
+
+    it "returns a 304 for standard sync requests with ETag headers" do # rubocop:disable RSpec/ExampleLength
+      post(
+        "/",
+        {},
+        {
+          "HTTP_ACCEPT" => "application/json",
+          "HTTP_IF_NONE_MATCH" => "\"abcd1234\"",
+          "CONTENT_TYPE" => "application/json"
+        }
+      )
+      expect(last_response.status).to eq(304)
+    end
+
+    it "does not provide a body for standard sync requests with ETag headers" do # rubocop:disable RSpec/ExampleLength
+      post(
+        "/",
+        {},
+        {
+          "HTTP_ACCEPT" => "application/json",
+          "HTTP_IF_NONE_MATCH" => "\"abcd1234\"",
+          "CONTENT_TYPE" => "application/json"
+        }
+      )
+      expect(last_response.body).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Adds support for Metacontroller's webhook [`etag`](https://metacontroller.github.io/metacontroller/api/hook.html#etag-reference) capabilities.

While I was tempted to use Sinatra's OOTB support for ETags via its `etag` helper, it appears that Sinatra is fully RFC7232 compliant, which means it responds with a `412` for `POST` requests that have a `If-None-Match` header that contains the `ETag` value rather than a `304`.

I created https://github.com/metacontroller/metacontroller/issues/850, but in the meantime, I wrote a custom light-weight implementation of ETag support in this PR that should suffice (with testing).