### PR TITLE
Fix rubocop complaint.

### DIFF
--- a/lib/metatron/templates/container.rb
+++ b/lib/metatron/templates/container.rb
@@ -42,7 +42,7 @@ module Metatron
           stdin:,
           tty:,
           terminationMessagePath:,
-          terminationMessagePolicy:,
+          terminationMessagePolicy:
         }.merge(probes)
           .merge(formatted_resources)
           .merge(formatted_environment)


### PR DESCRIPTION
I technically broke the build with my last PR since the tests hang indefinitely if rubocop lints dont pass.