### PR TITLE
Switching to sinatra's built-in etag support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metatron (0.4.0)
+    metatron (0.4.1)
       json (~> 2.6)
       puma (~> 6.3)
       sinatra (~> 3.1)

--- a/lib/metatron/sync_controller.rb
+++ b/lib/metatron/sync_controller.rb
@@ -9,15 +9,10 @@ module Metatron
     end
 
     post "/" do
-      # TODO: move this to Sinatra's `etag` helper when Metacontroller is RFC compliant
-      if (provided_etag = calculate_etag) &&
-         (match_header = request.env["HTTP_IF_NONE_MATCH"]) &&
-         match_header.split(/,\s?/).include?("\"#{provided_etag}\"")
-        halt 304
+      if (provided_etag = calculate_etag)
+        etag provided_etag
       end
 
-      # If the etag is available, use it, otherwise proceed with the sync
-      headers "ETag" => "\"#{provided_etag}\"" if provided_etag
       data = sync
       data[:children] = data[:children]&.map { |c| c.respond_to?(:render) ? c.render : c }
       halt(data.to_json)

--- a/lib/metatron/version.rb
+++ b/lib/metatron/version.rb
@@ -4,6 +4,6 @@ module Metatron
   VERSION = [
     0, # major
     4, # minor
-    0  # patch
+    1  # patch
   ].join(".")
 end

--- a/spec/metatron/sync_controller_spec.rb
+++ b/spec/metatron/sync_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Metatron::SyncController do
       expect(last_response.headers).to include("ETag" => "\"abcd1234\"")
     end
 
-    it "returns a 304 for standard sync requests with ETag headers" do # rubocop:disable RSpec/ExampleLength
+    it "returns a 412 for standard sync requests with ETag headers" do # rubocop:disable RSpec/ExampleLength
       post(
         "/",
         {},
@@ -87,7 +87,7 @@ RSpec.describe Metatron::SyncController do
           "CONTENT_TYPE" => "application/json"
         }
       )
-      expect(last_response.status).to eq(304)
+      expect(last_response.status).to eq(412)
     end
 
     it "does not provide a body for standard sync requests with ETag headers" do # rubocop:disable RSpec/ExampleLength


### PR DESCRIPTION
Now that metacontroller is RFC-compliant, it should be safe for the 0.4.x releases use Sinatra's built-in support for ETags.

Updated tests to reflect the proper 412 return value.