### PR TITLE
Add Metatron::Railtie for Rails integration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,8 @@ GEM
     nio4r (2.6.0)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.4-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -130,6 +132,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bundler (~> 2.3)

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "metatron"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/lib/metatron.rb
+++ b/lib/metatron.rb
@@ -16,10 +16,8 @@ module Metatron
   class Error < StandardError; end
   class ConfigError < Error; end
 
-  LOGGER = Logger.new($stdout)
-
-  # Set up log level
-  LOGGER.level = ENV.fetch("LOG_LEVEL", :warn)
+  singleton_class.attr_accessor :logger
+  self.logger = Logger.new($stdout, level: ENV.fetch("LOG_LEVEL", :warn))
 end
 
 # Internal requirements
@@ -50,3 +48,4 @@ require "metatron/templates/stateful_set"
 require "metatron/controller"
 require "metatron/sync_controller"
 require "metatron/controllers/ping"
+require "metatron/railtie" if defined? Rails::Railtie

--- a/lib/metatron/controller.rb
+++ b/lib/metatron/controller.rb
@@ -8,7 +8,7 @@ module Metatron
     configure do
       set :protection, except: :http_origin
       set :logging, true
-      set :logger, Metatron::LOGGER
+      set :logger, Metatron.logger
       set :show_exceptions, false
     end
 

--- a/lib/metatron/controllers/ping.rb
+++ b/lib/metatron/controllers/ping.rb
@@ -6,7 +6,7 @@ module Metatron
     class Ping < Sinatra::Application
       configure do
         set :logging, true
-        set :logger, Metatron::LOGGER
+        set :logger, Metatron.logger
       end
 
       before do

--- a/lib/metatron/railtie.rb
+++ b/lib/metatron/railtie.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Metatron
+  # Extension point for integrating with Rails applications
+  class Railtie < ::Rails::Railtie
+    initializer "metatron.logger" do
+      Metatron.logger = Rails.logger
+    end
+  end
+end


### PR DESCRIPTION
[Update Gemfile.lock with resolution for x86 linux](https://github.com/jgnagy/metatron/commit/4fc18dfe9b52dfd4320befb1b8780278838c068d)

---

[Add bin/console for easy debugging in irb](https://github.com/jgnagy/metatron/commit/ea94a4d8ff1f8b5b05d637456e26c04447f406b9)

This gets generated with gems created by bundler and I find it really
useful.

---

[Add Metatron::Railtie for Rails integration](https://github.com/jgnagy/metatron/commit/3179c3f028a18c56e8108dfa36f2d6c017d7f44e)

Additionally, change `Metatron::LOGGER` to `Metatron.logger` so that it
can be set to Rails.logger in the Railtie.