### PR TITLE
Make puma an optional dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     metatron (0.4.2)
       json (~> 2.6)
-      puma (~> 6.3)
       sinatra (~> 3.1)
       sinatra-contrib (~> 3.1)
 
@@ -27,7 +26,6 @@ GEM
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
-    nio4r (2.6.0)
     nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.15.4-x86_64-linux)
@@ -36,8 +34,6 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
-    puma (6.4.0)
-      nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8)
     rack-protection (3.1.0)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ As Metatron is a tool for creating Ruby projects, you'll need a few prerequistes
 $ git init blog_controller && cd blog_controller
 ```
 
-We'll need a `Gemfile` to ensure we have Metatron installed:
+We'll need a `Gemfile` to ensure we have installed both Metatron and a
+[`rack`][] compatible server:
 
 ```ruby
 # frozen_string_literal: true
@@ -128,9 +129,12 @@ We'll need a `Gemfile` to ensure we have Metatron installed:
 source "https://rubygems.org"
 
 gem "metatron"
+gem "puma"
 ```
 
-We'll also need a `config.ru` file to instruct [`rack`](https://github.com/rack/rack) how to route requests:
+[`rack`]: https://github.com/rack/rack
+
+We'll also need a `config.ru` file to instruct [`rack`][] how to route requests:
 
 ```ruby
 # frozen_string_literal: true

--- a/metatron.gemspec
+++ b/metatron.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 3.1"
 
   spec.add_runtime_dependency "json",                 "~> 2.6"
-  spec.add_runtime_dependency "puma",                 "~> 6.3"
   spec.add_runtime_dependency "sinatra",              "~> 3.1"
   spec.add_runtime_dependency "sinatra-contrib",      "~> 3.1"
 


### PR DESCRIPTION
Metatron is a Rack comforming application, which means it will actually work with any Rack compatible server. Making it a runtime dependency is unecessary and will likely just bite us later when a downstream application requires us to bump the puma requirement.

Instead, let's remove it as a runtime dependency. To ensure that the example in the README can still run with puma, it was added to the Gemfile as an example of a "rack compatible server".