### PR TITLE
Rackify Ping Controller

### DIFF
--- a/lib/metatron/controllers/ping.rb
+++ b/lib/metatron/controllers/ping.rb
@@ -3,35 +3,26 @@
 module Metatron
   module Controllers
     # Healthcheck service
-    class Ping < Sinatra::Application
+    class Ping
       RESPONSE = { status: "up" }.to_json
 
-      configure do
-        set :logging, true
-        set :logger, Metatron.logger
+      def call(env)
+        req = Rack::Request.new(env)
+
+        return access_control_allow_methods if req.options?
+        return [403, { Rack::CONTENT_TYPE => "application/json" }, []] unless req.get?
+
+        Rack::Response[200, {
+          "content-type" => "application/json",
+          "x-frame-options" => "SAMEORIGIN",
+          "x-xss-protection" => "1; mode=block"
+        }, [RESPONSE]].to_a
       end
 
-      before do
-        content_type "application/json"
+      private
 
-        halt 403 unless request.get? || request.options?
-
-        if request.get?
-          headers "X-Frame-Options" => "SAMEORIGIN"
-          headers "X-XSS-Protection" => "1; mode=block"
-        end
-      end
-
-      after do
-        headers "Access-Control-Allow-Methods" => %w[GET] if request.options?
-      end
-
-      get "/" do
-        RESPONSE
-      end
-
-      options "/" do
-        halt 200
+      def access_control_allow_methods
+        Rack::Response[200, { "access-control-allow-methods" => %w[GET] }, []].to_a
       end
     end
   end

--- a/lib/metatron/controllers/ping.rb
+++ b/lib/metatron/controllers/ping.rb
@@ -4,6 +4,8 @@ module Metatron
   module Controllers
     # Healthcheck service
     class Ping < Sinatra::Application
+      RESPONSE = { status: "up" }.to_json
+
       configure do
         set :logging, true
         set :logger, Metatron.logger
@@ -25,7 +27,7 @@ module Metatron
       end
 
       get "/" do
-        '{ "status": "up" }'
+        RESPONSE
       end
 
       options "/" do

--- a/spec/metatron/controllers/ping_spec.rb
+++ b/spec/metatron/controllers/ping_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rack/test"
+
+RSpec.describe Metatron::Controllers::Ping do
+  include Rack::Test::Methods
+
+  let(:app) { Rack::Lint.new(described_class.new) }
+
+  it "returns a 200 status" do
+    get "/"
+    expect(last_response.status).to eq(200)
+  end
+
+  it "returns a JSON response body" do
+    get "/"
+    expect(last_response.body).to eq({ status: "up" }.to_json)
+  end
+
+  it "responds with JSON content-type header" do
+    get "/"
+    expect(last_response.headers["content-type"]).to eq("application/json")
+  end
+
+  it "returns a 403 status for invalid request methods" do
+    post "/"
+    expect(last_response.status).to eq(403)
+  end
+
+  it "returns allowed request methods on options request" do
+    options "/"
+    expect(last_response.headers["access-control-allow-methods"]).to eq(["GET"])
+  end
+end


### PR DESCRIPTION
[Add specs for ping controller](https://github.com/jgnagy/metatron/commit/5308def4b42c51235394691ba57aed927374e51a)

---

[Rackify Ping Controller](https://github.com/jgnagy/metatron/commit/9083ae28fd101d3d61c8add3e9f0843265b8fcdf)

This keeps everything that the Sinatra version did previously except for
logging. The use of Rack::Response and Rack::CONTENT_TYPE are to ensure
that we support both versions 2 and 3 of Rack.