### PR TITLE
Rackify Controller and CompositeController

### DIFF
--- a/lib/metatron/composite_controller.rb
+++ b/lib/metatron/composite_controller.rb
@@ -4,45 +4,9 @@ module Metatron
   # Implementes a Metacontroller CompositeController
   # @see https://metacontroller.github.io/metacontroller/api/compositecontroller.html
   class CompositeController < Controller
-    options "/sync" do
-      headers "Access-Control-Allow-Methods" => ["POST"]
-      halt 200
-    end
-
-    post "/sync" do
-      if (provided_etag = calculate_sync_etag)
-        etag provided_etag
-      end
-
-      data = sync
-      data[:children] = data[:children]&.map { |c| c.respond_to?(:render) ? c.render : c }
-      halt(data.to_json)
-    end
-
-    options "/finalize" do
-      headers "Access-Control-Allow-Methods" => ["POST"]
-      halt 200
-    end
-
-    post "/finalize" do
-      # finalize calls should be rare and unique enough that we don't need to worry about ETags
-
-      data = finalize
-      data[:children] = data[:children]&.map { |c| c.respond_to?(:render) ? c.render : c }
-      halt(data.to_json)
-    end
-
-    options "/customize" do
-      headers "Access-Control-Allow-Methods" => ["POST"]
-      halt 200
-    end
-
-    post "/customize" do
-      if (provided_etag = calculate_customize_etag)
-        etag provided_etag
-      end
-
-      halt(customize.to_json)
+    def initialize(env)
+      super
+      @strategy = nil
     end
 
     def calculate_customize_etag = nil
@@ -50,5 +14,55 @@ module Metatron
     def customize = raise NotImplementedError
     def finalize = raise NotImplementedError
     def sync = raise NotImplementedError
+
+    private
+
+    STRATEGY = {
+      "/customize" => { data: :customize, etag: :calculate_customize_etag },
+      # finalize calls should be rare and unique enough that we don't need to worry about ETags
+      "/finalize" => { data: :finalize },
+      "/sync" => { data: :sync, etag: :calculate_sync_etag }
+    }.freeze
+
+    def _call
+      return access_control_allow_methods if request.options?
+      return not_found unless request.post?
+
+      @strategy = STRATEGY.fetch(request.path_info) { return not_found }
+
+      headers = {}
+
+      return Rack::Response[412, headers, []].to_a if etag_matches?(headers)
+
+      Rack::Response[200, headers, processed_data].to_a
+    end
+
+    def access_control_allow_methods
+      Rack::Response[200, { "access-control-allow-methods" => %w[POST] }, []].to_a
+    end
+
+    def not_found
+      Rack::Response[404, { "x-cascade" => "pass" }, []].to_a
+    end
+
+    def etag_matches?(headers)
+      return false unless (calculator = @strategy[:etag])
+      return false unless (raw_etag = public_send(calculator))
+
+      etag = +'"' << raw_etag << '"'
+      headers["etag"] = etag
+
+      (none_match = request.get_header("HTTP_IF_NONE_MATCH")) && none_match.include?(etag)
+    end
+
+    def processed_data
+      data = public_send(@strategy[:data])
+
+      if data[:children]
+        data[:children] = data[:children].map { |c| c.respond_to?(:render) ? c.render : c }
+      end
+
+      data.to_json
+    end
   end
 end

--- a/lib/metatron/controller.rb
+++ b/lib/metatron/controller.rb
@@ -2,37 +2,37 @@
 
 module Metatron
   # Base class for API services
-  class Controller < Sinatra::Base
-    helpers Sinatra::CustomLogger
-
-    configure do
-      set :protection, except: :http_origin
-      set :logging, true
-      set :logger, Metatron.logger
-      set :show_exceptions, false
-    end
-
-    before do
-      # Sets up a useful variable (@json_body) for accessing a parsed request body
-      if request.content_type&.include?("json") && !request.body.read.empty?
-        request.body.rewind
-        @json_body = JSON.parse(request.body.read)
+  class Controller
+    class << self
+      def call(env)
+        new(env).call
       end
-    rescue StandardError => e
-      halt(400, { error: "Request must be JSON: #{e.message}}" }.to_json)
     end
 
-    error do
-      content_type :json
+    attr_accessor :request_body
 
-      e = env["sinatra.error"]
-      resp = { result: "error", message: e.message }
-      resp[:trace] = e.full_message if settings.environment.to_s != "production"
-      resp.to_json
+    def initialize(env)
+      @env = env
+      @request = Rack::Request.new(env)
     end
 
-    def request_body
-      @json_body
+    def call
+      begin
+        if request&.content_type&.include?("json")
+          body = request.body.read
+          request.body.rewind if request.body.respond_to?(:rewind)
+
+          self.request_body = JSON.parse(body) unless body.empty?
+        end
+      rescue JSON::ParserError => e
+        return [400, {}, [{ error: "Request must be JSON: #{e.message}" }.to_json]]
+      end
+
+      _call
     end
+
+    private
+
+    attr_reader :request
   end
 end

--- a/spec/metatron/composite_controller_spec.rb
+++ b/spec/metatron/composite_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Metatron::CompositeController do
   include Rack::Test::Methods
 
   context "when ETag support is NOT enabled" do
-    def app = TestController
+    let(:app) { Rack::Lint.new(TestController) }
 
     it "returns a 200 OK for initial sync requests" do
       post "/sync", {}, "HTTP_ACCEPT" => "application/json", "Content-Type" => "application/json"
@@ -34,7 +34,7 @@ RSpec.describe Metatron::CompositeController do
 
     it "does not provide an ETag header for initial sync requests" do
       post "/sync", {}, "HTTP_ACCEPT" => "application/json", "Content-Type" => "application/json"
-      expect(last_response.headers.keys).not_to include("ETag")
+      expect(last_response.headers.key?("etag")).to be(false)
     end
 
     it "returns a 200 for standard sync requests" do
@@ -120,7 +120,7 @@ RSpec.describe Metatron::CompositeController do
           "Content-Type" => "application/json"
         }
       )
-      expect(last_response.headers.keys).not_to include("ETag")
+      expect(last_response.headers.key?("etag")).to be(false)
     end
 
     it "returns a 200 for standard customize requests" do
@@ -151,7 +151,7 @@ RSpec.describe Metatron::CompositeController do
   end
 
   context "when ETag support is enabled" do
-    def app = TestControllerWithEtags
+    let(:app) { Rack::Lint.new(TestControllerWithEtags) }
 
     it "returns a 200 OK for initial sync requests" do
       post "/sync", {}, "HTTP_ACCEPT" => "application/json", "Content-Type" => "application/json"
@@ -165,7 +165,7 @@ RSpec.describe Metatron::CompositeController do
 
     it "returns the expected ETag header for initial sync requests" do
       post "/sync", {}, "HTTP_ACCEPT" => "application/json", "Content-Type" => "application/json"
-      expect(last_response.headers).to include("ETag" => "\"abcd1234\"")
+      expect(last_response.headers["etag"]).to eq("\"abcd1234\"")
     end
 
     it "returns a 412 for standard sync requests with ETag headers" do
@@ -227,7 +227,7 @@ RSpec.describe Metatron::CompositeController do
           "Content-Type" => "application/json"
         }
       )
-      expect(last_response.headers).to include("ETag" => "\"efgh5678\"")
+      expect(last_response.headers["etag"]).to eq("\"efgh5678\"")
     end
 
     it "returns a 412 for standard customize requests with ETag headers" do


### PR DESCRIPTION
[Update CompositeControler specs for Rack 3](https://github.com/jgnagy/metatron/commit/92ded2c006f326098abc0b112ec0f483a8e5af65)

There are two changes being done here:
- adding Rack::Lint to ensure our requests and responses adhere to the
  Rack spec (currently 2, but once Sinatra is removed we can run a
  matrix against Rack 2 and 3)
- updating some assertions to play nice with Rack 3's downcased headers.
  With Rack 2 we can assert with downcased headers as long as we use
  methods included in Rack::Utils::HeaderHash. Once we only support Rack
  3, then the response headers will be a simple Hash again and these
  changes can be partially reverted

---

[Rackify Controller and CompositeController](https://github.com/jgnagy/metatron/commit/18703e1401c4285cafeac46e0434988ed7e23c74)

This removes Sinatra as the underlying class of Controller and
CompositeController and replaces features previously implemented by
Sinatra with plain Rack.

The most notable feature kept is ETags/Conditional Get which is kept
using the If-None-Match header.

An additional thing it note is that Controller is implemented slightly
differently than PingController. PingController does not really carry
any state so it's implemented as a persistent instance that can be
called. Metatron::Controller does want to carry some state that can be
used in the implementing class's methods, so intead of a single instance
the Controller will be instantiated per request when called.