### PR TITLE
Refactor template.rb to use base_labels

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metatron (0.6.0)
+    metatron (0.6.1)
       json (~> 2.6)
       rack (>= 2.2.8, < 4)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metatron (0.5.0)
+    metatron (0.6.0)
       json (~> 2.6)
       rack (>= 2.2.8, < 4)
 

--- a/lib/metatron/template.rb
+++ b/lib/metatron/template.rb
@@ -12,6 +12,28 @@ module Metatron
       def label_namespace
         @label_namespace ||= "metatron.therubyist.org"
       end
+
+      def initializer(*args)
+        @initializers ||= []
+        @initializers += args
+      end
+
+      def initializers
+        @initializers ||= []
+      end
+
+      def nearest_metatron_ancestor
+        return self if metatron_template_class?
+
+        ancestors.find { _1.respond_to?(:metatron_template_class?) && _1.metatron_template_class? }
+      end
+
+      def metatron_template_class?
+        return true if name == "Metatron::Template"
+        return false if name.start_with?("Metatron::Templates::Concerns")
+
+        name.start_with?("Metatron::Templates::")
+      end
     end
 
     def initialize(name)
@@ -25,27 +47,7 @@ module Metatron
 
     alias apiVersion api_version
 
-    def self.initializer(*args)
-      @initializers ||= []
-      @initializers += args
-    end
-
-    def self.initializers
-      @initializers ||= []
-    end
-
-    def self.nearest_metatron_ancestor
-      return self if metatron_template_class?
-
-      ancestors.find { _1.respond_to?(:metatron_template_class?) && _1.metatron_template_class? }
-    end
-
-    def self.metatron_template_class?
-      return true if name == "Metatron::Template"
-      return false if name.start_with?("Metatron::Templates::Concerns")
-
-      name.start_with?("Metatron::Templates::")
-    end
+    def base_labels = { "#{label_namespace}/name": name }
 
     private
 

--- a/lib/metatron/templates/cluster_role.rb
+++ b/lib/metatron/templates/cluster_role.rb
@@ -22,7 +22,7 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).compact,
           aggregationRule:,
           rules: formatted_rules

--- a/lib/metatron/templates/cluster_role_binding.rb
+++ b/lib/metatron/templates/cluster_role_binding.rb
@@ -28,7 +28,7 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).compact,
           roleRef:,
           subjects:

--- a/lib/metatron/templates/concerns/pod_producer.rb
+++ b/lib/metatron/templates/concerns/pod_producer.rb
@@ -104,7 +104,7 @@ module Metatron
         def pod_metadata
           {
             metadata: {
-              labels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
+              labels: base_labels.merge(additional_pod_labels)
             }.merge(formatted_pod_annotations)
           }
         end

--- a/lib/metatron/templates/config_map.rb
+++ b/lib/metatron/templates/config_map.rb
@@ -23,7 +23,7 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).merge(formatted_namespace).compact,
           data:,
           immutable:

--- a/lib/metatron/templates/cron_job.rb
+++ b/lib/metatron/templates/cron_job.rb
@@ -30,7 +30,7 @@ module Metatron
           apiVersion:,
           kind:,
           metadata: {
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels),
+            labels: base_labels.merge(additional_labels),
             name:
           }.merge(formatted_annotations).merge(formatted_namespace),
           spec: {

--- a/lib/metatron/templates/daemon_set.rb
+++ b/lib/metatron/templates/daemon_set.rb
@@ -21,11 +21,11 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).merge(formatted_namespace),
           spec: {
             selector: {
-              matchLabels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
+              matchLabels: base_labels.merge(additional_pod_labels)
             }
           }.merge(pod_template)
         }

--- a/lib/metatron/templates/deployment.rb
+++ b/lib/metatron/templates/deployment.rb
@@ -22,13 +22,13 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).merge(formatted_namespace),
           spec: {
             replicas:,
             strategy:,
             selector: {
-              matchLabels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
+              matchLabels: base_labels.merge(additional_pod_labels)
             }
           }.merge(pod_template).compact
         }

--- a/lib/metatron/templates/ingress.rb
+++ b/lib/metatron/templates/ingress.rb
@@ -77,7 +77,7 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).merge(formatted_namespace),
           spec: formatted_rules.merge(formatted_tls)
         }

--- a/lib/metatron/templates/job.rb
+++ b/lib/metatron/templates/job.rb
@@ -28,7 +28,7 @@ module Metatron
           apiVersion:,
           kind:,
           metadata: {
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels),
+            labels: base_labels.merge(additional_labels),
             name:
           }.merge(formatted_annotations).merge(formatted_namespace),
           spec: {

--- a/lib/metatron/templates/namespace.rb
+++ b/lib/metatron/templates/namespace.rb
@@ -19,7 +19,7 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations)
         }
       end

--- a/lib/metatron/templates/persistent_volume_claim.rb
+++ b/lib/metatron/templates/persistent_volume_claim.rb
@@ -31,7 +31,7 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).merge(formatted_namespace),
           spec: {
             accessModes:,

--- a/lib/metatron/templates/pod.rb
+++ b/lib/metatron/templates/pod.rb
@@ -13,7 +13,7 @@ module Metatron
           apiVersion:,
           kind:,
           metadata: {
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels),
+            labels: base_labels.merge(additional_labels),
             name:
           }.merge(formatted_annotations).merge(formatted_namespace)
         }.merge(pod_spec)

--- a/lib/metatron/templates/replica_set.rb
+++ b/lib/metatron/templates/replica_set.rb
@@ -22,12 +22,12 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).merge(formatted_namespace),
           spec: {
             replicas:,
             selector: {
-              matchLabels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
+              matchLabels: base_labels.merge(additional_pod_labels)
             }
           }.merge(pod_template)
         }

--- a/lib/metatron/templates/role.rb
+++ b/lib/metatron/templates/role.rb
@@ -21,7 +21,7 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).merge(formatted_namespace).compact,
           rules: formatted_rules
         }.compact

--- a/lib/metatron/templates/role_binding.rb
+++ b/lib/metatron/templates/role_binding.rb
@@ -29,7 +29,7 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).merge(formatted_namespace).compact,
           roleRef:,
           subjects:

--- a/lib/metatron/templates/secret.rb
+++ b/lib/metatron/templates/secret.rb
@@ -22,7 +22,7 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).merge(formatted_namespace).compact,
           type:,
           stringData: data

--- a/lib/metatron/templates/service.rb
+++ b/lib/metatron/templates/service.rb
@@ -13,7 +13,7 @@ module Metatron
       def initialize(name, port = nil)
         super(name)
         @type = "ClusterIP"
-        @selector = { "#{label_namespace}/name": name }
+        @selector = base_labels
         @additional_labels = {}
         @additional_selector_labels = {}
         @publish_not_ready_addresses = false
@@ -41,7 +41,7 @@ module Metatron
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).merge(formatted_namespace),
           spec: {
             type:,

--- a/lib/metatron/templates/service_account.rb
+++ b/lib/metatron/templates/service_account.rb
@@ -18,7 +18,7 @@ module Metatron
           automountServiceAccountToken:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).merge(formatted_namespace).compact
         }.compact
       end

--- a/lib/metatron/templates/stateful_set.rb
+++ b/lib/metatron/templates/stateful_set.rb
@@ -25,20 +25,20 @@ module Metatron
       alias strategy= update_strategy=
       alias updateStrategy update_strategy
 
-      def render # rubocop:disable Metrics/AbcSize
+      def render
         {
           apiVersion:,
           kind:,
           metadata: {
             name:,
-            labels: { "#{label_namespace}/name": name }.merge(additional_labels)
+            labels: base_labels.merge(additional_labels)
           }.merge(formatted_annotations).merge(formatted_namespace),
           spec: {
             replicas:,
             serviceName:,
             updateStrategy:,
             selector: {
-              matchLabels: { "#{label_namespace}/name": name }.merge(additional_pod_labels)
+              matchLabels: base_labels.merge(additional_pod_labels)
             }
           }.merge(pod_template).merge(volume_claim_templates).compact
         }

--- a/lib/metatron/version.rb
+++ b/lib/metatron/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Metatron
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
Refactoring to `base_labels` rather than explicitly creating these same base labels on each template.

This will allow future updates to the base labels if we'd like.