### PR TITLE
replace alias with method definitions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    metatron (0.8.4)
+    metatron (0.8.5)
       json (~> 2.6)
       rack (>= 2.2.8, < 4)
 

--- a/lib/metatron/templates/service.rb
+++ b/lib/metatron/templates/service.rb
@@ -31,8 +31,10 @@ module Metatron
         ]
       end
 
-      alias publishNotReadyAddresses publish_not_ready_addresses
-      alias clusterIP cluster_ip
+      # rubocop:disable Naming/MethodName
+      def publishNotReadyAddresses = publish_not_ready_addresses
+      def clusterIP = cluster_ip
+      # rubocop:enable Naming/MethodName
 
       def formatted_ports
         ports&.any? ? { ports: } : {}

--- a/lib/metatron/version.rb
+++ b/lib/metatron/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Metatron
-  VERSION = "0.8.4"
+  VERSION = "0.8.5"
 end


### PR DESCRIPTION
aliases do not work with subclassing and redefining methods, replacing them with methods instead