### PR TITLE
Adds dataSource and dataSourceRef to PVCs

### DIFF
--- a/lib/metatron/templates/persistent_volume_claim.rb
+++ b/lib/metatron/templates/persistent_volume_claim.rb
@@ -7,10 +7,13 @@ module Metatron
       include Concerns::Annotated
       include Concerns::Namespaced
 
-      attr_accessor :additional_labels, :storage_class, :access_modes, :storage
+      attr_accessor :additional_labels, :data_source, :data_source_ref, :storage_class,
+                    :access_modes, :storage
 
       alias storageClassName storage_class
       alias accessModes access_modes
+      alias dataSource data_source
+      alias dataSourceRef data_source_ref
 
       def initialize(
         name,
@@ -22,6 +25,7 @@ module Metatron
         @storage_class = storage_class
         @access_modes = access_modes
         @storage = storage
+        @data_source = {}
         @additional_labels = {}
       end
 
@@ -41,8 +45,32 @@ module Metatron
                 storage:
               }
             }
-          }
+          }.merge(formatted_data_source).merge(formatted_data_source_ref)
         }
+      end
+
+      def formatted_data_source
+        return {} unless data_source && !data_source.empty?
+        raise "dataSource must be a Hash" unless data_source.is_a?(Hash)
+
+        valid_keys = %i[apiGroup kind name]
+        unless data_source.keys.all? { valid_keys.include?(_1.to_sym) }
+          raise "dataSource may contain only the keys: #{valid_keys.join(", ")}"
+        end
+
+        { dataSource: data_source.transform_keys(&:to_sym) }
+      end
+
+      def formatted_data_source_ref
+        return {} unless data_source_ref && !data_source_ref.empty?
+        raise "dataSourceRef must be a Hash" unless data_source_ref.is_a?(Hash)
+
+        valid_keys = %i[apiGroup kind name namespace]
+        unless data_source_ref.keys.all? { valid_keys.include?(_1.to_sym) }
+          raise "dataSourceRef may contain only the keys: #{valid_keys.join(", ")}"
+        end
+
+        { dataSourceRef: data_source_ref.transform_keys(&:to_sym) }
       end
     end
   end

--- a/spec/metatron/templates/persistent_volume_claim_spec.rb
+++ b/spec/metatron/templates/persistent_volume_claim_spec.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe Metatron::Templates::PersistentVolumeClaim do
-  let(:pvc) { described_class.new("test", storage_class: "test", storage: "1Gi") }
+  let(:pvc) do
+    described_class.new("test", storage_class: "test", storage: "1Gi").tap do |pvc|
+      pvc.data_source = { name: "existing-src-pvc-name", kind: "PersistentVolumeClaim" }
+    end
+  end
 
   let(:rendered_pvc) do
     {
@@ -13,6 +17,10 @@ RSpec.describe Metatron::Templates::PersistentVolumeClaim do
       },
       spec: {
         accessModes: ["ReadWriteOnce"],
+        dataSource: {
+          name: "existing-src-pvc-name",
+          kind: "PersistentVolumeClaim"
+        },
         storageClassName: "test",
         resources: {
           requests: {


### PR DESCRIPTION
Closes #41

Adds support for `spec.dataSource` and `spec.dataSourceRef` to the `PersistentVolumeClaim` template.

Includes some validations on supported keys plus minimal testing.