### PR TITLE
Better handling of automated template pod labels

### DIFF
--- a/lib/metatron/template.rb
+++ b/lib/metatron/template.rb
@@ -4,7 +4,8 @@ module Metatron
   # Base class for templating Kubernetes resources
   class Template
     attr_accessor :api_version, :name, :additional_labels
-    attr_reader :kind, :label_namespace
+    attr_reader :kind
+    attr_writer :base_labels
 
     class << self
       attr_writer :label_namespace
@@ -38,7 +39,6 @@ module Metatron
 
     def initialize(name)
       @name = name
-      @label_namespace = self.class.label_namespace
       @api_version = "v1"
       @kind = find_kind
       @additional_labels = {}
@@ -47,9 +47,14 @@ module Metatron
 
     alias apiVersion api_version
 
-    def base_labels = { "#{label_namespace}/name": name }
+    def base_labels
+      @base_labels || { "#{label_namespace}/name": name }
+    end
 
     private
+
+    # defers to the nearest metatron ancestor to determine the label namespace
+    def label_namespace = self.class.label_namespace
 
     def run_initializers
       self.class.nearest_metatron_ancestor.initializers.each { send(_1.to_sym) }

--- a/lib/metatron/templates/concerns/pod_producer.rb
+++ b/lib/metatron/templates/concerns/pod_producer.rb
@@ -9,10 +9,10 @@ module Metatron
           # base.extend ClassMethods
           base.class_eval do
             attr_accessor :active_deadline_seconds, :additional_pod_labels,
-                          :affinity, :automount_service_account_token, :containers,
-                          :dns_policy, :enable_service_links, :hostname, :host_ipc, :host_network,
-                          :host_pid, :image_pull_secrets, :init_containers, :node_selector,
-                          :node_name, :persistent_volume_claims, :pod_annotations,
+                          :additional_pod_match_labels, :affinity, :automount_service_account_token,
+                          :containers, :dns_policy, :enable_service_links, :hostname, :host_ipc,
+                          :host_network, :host_pid, :image_pull_secrets, :init_containers,
+                          :node_selector, :node_name, :persistent_volume_claims, :pod_annotations,
                           :priority_class_name, :restart_policy, :scheduler_name, :security_context,
                           :service_account, :service_account_name, :share_process_namespace,
                           :subdomain, :termination_grace_period_seconds, :tolerations, :volumes
@@ -41,6 +41,7 @@ module Metatron
 
         def pod_producer_initialize
           @additional_pod_labels = {}
+          @additional_pod_match_labels = {}
           @affinity = {}
           @containers = []
           @enable_service_links = nil

--- a/lib/metatron/templates/daemon_set.rb
+++ b/lib/metatron/templates/daemon_set.rb
@@ -25,7 +25,7 @@ module Metatron
           }.merge(formatted_annotations).merge(formatted_namespace),
           spec: {
             selector: {
-              matchLabels: base_labels.merge(additional_pod_labels)
+              matchLabels: base_labels.merge(additional_pod_match_labels)
             }
           }.merge(pod_template)
         }

--- a/lib/metatron/templates/deployment.rb
+++ b/lib/metatron/templates/deployment.rb
@@ -28,7 +28,7 @@ module Metatron
             replicas:,
             strategy:,
             selector: {
-              matchLabels: base_labels.merge(additional_pod_labels)
+              matchLabels: base_labels.merge(additional_pod_match_labels)
             }
           }.merge(pod_template).compact
         }

--- a/lib/metatron/templates/replica_set.rb
+++ b/lib/metatron/templates/replica_set.rb
@@ -27,7 +27,7 @@ module Metatron
           spec: {
             replicas:,
             selector: {
-              matchLabels: base_labels.merge(additional_pod_labels)
+              matchLabels: base_labels.merge(additional_pod_match_labels)
             }
           }.merge(pod_template)
         }

--- a/lib/metatron/templates/stateful_set.rb
+++ b/lib/metatron/templates/stateful_set.rb
@@ -38,7 +38,7 @@ module Metatron
             serviceName:,
             updateStrategy:,
             selector: {
-              matchLabels: base_labels.merge(additional_pod_labels)
+              matchLabels: base_labels.merge(additional_pod_match_labels)
             }
           }.merge(pod_template).merge(volume_claim_templates).compact
         }

--- a/spec/metatron/template_spec.rb
+++ b/spec/metatron/template_spec.rb
@@ -23,6 +23,25 @@ RSpec.describe Metatron::Template do
       thing = FakeConfigMap.new("test", { "foo" => "bar" })
       expect(thing.annotations).to eq({}) # this is set by Concerns::Annotated#annotated_initialize
     end
+
+    it "uses the correct base label namespace" do
+      actual_labels = FakeConfigMap.new("test", { "foo" => "bar" }).render[:metadata][:labels]
+      expect(actual_labels.keys).to include(:"metatron.therubyist.org/name")
+    end
+
+    it "allows using a different base label namespace" do
+      FakeConfigMap.label_namespace = "example.com"
+      actual_labels = FakeConfigMap.new("test", { "foo" => "bar" }).render[:metadata][:labels]
+      expect(actual_labels.keys).to include(:"example.com/name")
+      FakeConfigMap.label_namespace = "metatron.therubyist.org"
+    end
+
+    it "allows setting the base labels directly on template instances" do
+      cm = FakeConfigMap.new("test", { "foo" => "bar" })
+      cm.base_labels = { "baz" => "qux" }
+      actual_labels = cm.render[:metadata][:labels]
+      expect(actual_labels).to eq({ "baz" => "qux" })
+    end
   end
 end
 

--- a/spec/metatron/templates/daemon_set_spec.rb
+++ b/spec/metatron/templates/daemon_set_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe Metatron::Templates::DaemonSet do
       ds.annotations = { "a.test/foo": "bar" }
       ds.additional_labels = { "app.kubernetes.io/part-of": "test-app" }
       ds.namespace = "test-namespace"
-      ds.additional_pod_labels = { thing: "swamp" }
+      ds.additional_pod_labels = { them: "hills", thing: "swamp" }
+      ds.additional_pod_match_labels = { thing: "swamp" }
       ds.security_context = { runAsUser: 1000, runAsGroup: 1000 }
       ds.volumes = [{ name: "tmpvol", emptyDir: {} }]
 
@@ -109,7 +110,7 @@ RSpec.describe Metatron::Templates::DaemonSet do
           },
           template: {
             metadata: {
-              labels: { "metatron.therubyist.org/name": "test", thing: "swamp" }
+              labels: { "metatron.therubyist.org/name": "test", them: "hills", thing: "swamp" }
             },
             spec: {
               containers: [

--- a/spec/metatron/templates/deployment_spec.rb
+++ b/spec/metatron/templates/deployment_spec.rb
@@ -86,7 +86,8 @@ RSpec.describe Metatron::Templates::Deployment do
       dep.namespace = "test-namespace"
       dep.replicas = 10
       dep.strategy = { type: "RollingUpdate", rollingUpdate: { maxSurge: 1, maxUnavailable: 0 } }
-      dep.additional_pod_labels = { thing: "swamp" }
+      dep.additional_pod_labels = { them: "hills", thing: "swamp" }
+      dep.additional_pod_match_labels = { thing: "swamp" }
       dep.security_context = { runAsUser: 1000, runAsGroup: 1000 }
       dep.volumes = [{ name: "tmpvol", emptyDir: {} }]
 
@@ -114,7 +115,7 @@ RSpec.describe Metatron::Templates::Deployment do
           },
           template: {
             metadata: {
-              labels: { "metatron.therubyist.org/name": "test", thing: "swamp" }
+              labels: { "metatron.therubyist.org/name": "test", them: "hills", thing: "swamp" }
             },
             spec: {
               containers: [

--- a/spec/metatron/templates/replica_set_spec.rb
+++ b/spec/metatron/templates/replica_set_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe Metatron::Templates::ReplicaSet do
       rs.annotations = { "a.test/foo": "bar" }
       rs.additional_labels = { "app.kubernetes.io/part-of": "test-app" }
       rs.replicas = 10
-      rs.additional_pod_labels = { thing: "swamp" }
+      rs.additional_pod_labels = { them: "hills", thing: "swamp" }
+      rs.additional_pod_match_labels = { thing: "swamp" }
       rs.security_context = { runAsUser: 1000, runAsGroup: 1000 }
       rs.volumes = [{ name: "tmpvol", emptyDir: {} }]
 
@@ -100,7 +101,7 @@ RSpec.describe Metatron::Templates::ReplicaSet do
           },
           template: {
             metadata: {
-              labels: { "metatron.therubyist.org/name": "test", thing: "swamp" }
+              labels: { "metatron.therubyist.org/name": "test", them: "hills", thing: "swamp" }
             },
             spec: {
               containers: [

--- a/spec/metatron/templates/stateful_set_spec.rb
+++ b/spec/metatron/templates/stateful_set_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe Metatron::Templates::StatefulSet do
         rollingUpdate: { maxSurge: 2, maxUnavailable: 0 }, type: "RollingUpdate"
       }
       stateful_set.termination_grace_period_seconds = 10
-      stateful_set.additional_pod_labels = { foo: "bar" }
+      stateful_set.additional_pod_labels = { foo: "bar", them: "hills" }
+      stateful_set.additional_pod_match_labels = { foo: "bar" }
       stateful_set.service_name = "a-test"
       stateful_set.persistent_volume_claims = [
         Metatron::Templates::PersistentVolumeClaim.new("test", storage_class: "test",
@@ -96,7 +97,8 @@ RSpec.describe Metatron::Templates::StatefulSet do
           updateStrategy: { rollingUpdate: { maxSurge: 2, maxUnavailable: 0 },
                             type: "RollingUpdate" },
           template: {
-            metadata: { labels: { "metatron.therubyist.org/name": "test", foo: "bar" } },
+            metadata: { labels: { "metatron.therubyist.org/name": "test", foo: "bar",
+                                  them: "hills" } },
             spec: {
               containers: [
                 {


### PR DESCRIPTION
Resolves #72 

Base labels can now be completely overridden, even at a per template instance level, as opposed to the previous behavior only allowing changing the label namespace at a global level.

Pod selector match labels, used by pod producers, must now be explicitly set rather than assuming and merging in `additional_pod_labels`. This allows adding pods labels in pod producer templates (Deployment, StatefulSet, etc.) without those automatically being used to match.