### PR TITLE
More Options for Ping Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 
 Metatron is a Ruby library for creating [Metacontroller](https://metacontroller.github.io/metacontroller/)-based custom Kubernetes controllers.
 
-The intention is to make it as easy as possible to use Ruby to manage [custom resources](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) within your Kubernetes infrastructure. No Golang required!
+The intention is to make it as easy as possible to use Ruby to manage [custom resources](https://kubernetes.io/docs/concepts/api-extension/custom-resources/) within your Kubernetes infrastructure. No Golang required! Use simple, Rack-based controllers to provide the logic for your custom resources. Metatron templates provide a most Kubernetes boilerplate code for you, so you can focus on the logic that enables your custom resources to do what you need them to do.
 
 For more information, see the [Metatron Wiki on GitHub](https://github.com/jgnagy/metatron/wiki)!
 
 For help on how to get started, take a look at the [User Guide](https://github.com/jgnagy/metatron/wiki/User-Guide) in the Wiki!
+
+## Contributing
+
+If you're interested in contributing to Metatron, please see the [Contributing Guide](CONTRIBUTING.md) in the repository! Be sure to check out the [Code of Conduct](CODE_OF_CONDUCT.md) as well!

--- a/lib/metatron/controllers/ping.rb
+++ b/lib/metatron/controllers/ping.rb
@@ -6,6 +6,10 @@ module Metatron
     class Ping
       RESPONSE = { status: "up" }.to_json
 
+      class << self
+        def call(env) = new.call(env)
+      end
+
       def call(env)
         req = Rack::Request.new(env)
 

--- a/spec/metatron/controllers/ping_spec.rb
+++ b/spec/metatron/controllers/ping_spec.rb
@@ -6,30 +6,61 @@ require "rack/test"
 RSpec.describe Metatron::Controllers::Ping do
   include Rack::Test::Methods
 
-  let(:app) { Rack::Lint.new(described_class.new) }
+  describe "as a class" do
+    let(:app) { Rack::Lint.new(described_class) }
 
-  it "returns a 200 status" do
-    get "/"
-    expect(last_response.status).to eq(200)
+    it "returns a 200 status" do
+      get "/"
+      expect(last_response.status).to eq(200)
+    end
+
+    it "returns a JSON response body" do
+      get "/"
+      expect(last_response.body).to eq({ status: "up" }.to_json)
+    end
+
+    it "responds with JSON content-type header" do
+      get "/"
+      expect(last_response.headers["content-type"]).to eq("application/json")
+    end
+
+    it "returns a 403 status for invalid request methods" do
+      post "/"
+      expect(last_response.status).to eq(403)
+    end
+
+    it "returns allowed request methods on options request" do
+      options "/"
+      expect(last_response.headers["access-control-allow-methods"]).to eq(["GET"])
+    end
   end
 
-  it "returns a JSON response body" do
-    get "/"
-    expect(last_response.body).to eq({ status: "up" }.to_json)
-  end
+  describe "as an instance" do
+    let(:app) { Rack::Lint.new(described_class.new) }
 
-  it "responds with JSON content-type header" do
-    get "/"
-    expect(last_response.headers["content-type"]).to eq("application/json")
-  end
+    it "returns a 200 status" do
+      get "/"
+      expect(last_response.status).to eq(200)
+    end
 
-  it "returns a 403 status for invalid request methods" do
-    post "/"
-    expect(last_response.status).to eq(403)
-  end
+    it "returns a JSON response body" do
+      get "/"
+      expect(last_response.body).to eq({ status: "up" }.to_json)
+    end
 
-  it "returns allowed request methods on options request" do
-    options "/"
-    expect(last_response.headers["access-control-allow-methods"]).to eq(["GET"])
+    it "responds with JSON content-type header" do
+      get "/"
+      expect(last_response.headers["content-type"]).to eq("application/json")
+    end
+
+    it "returns a 403 status for invalid request methods" do
+      post "/"
+      expect(last_response.status).to eq(403)
+    end
+
+    it "returns allowed request methods on options request" do
+      options "/"
+      expect(last_response.headers["access-control-allow-methods"]).to eq(["GET"])
+    end
   end
 end


### PR DESCRIPTION
`Metatron::Controllers::Ping` can now be used just like other Rack apps, either as a class or via `#new`.

Also made some minor README updates