### PR TITLE
Add additional features to cron job template

### DIFF
--- a/lib/metatron/templates/cron_job.rb
+++ b/lib/metatron/templates/cron_job.rb
@@ -10,13 +10,16 @@ module Metatron
 
       attr_accessor :schedule, :suspend, :concurrency_policy, :starting_deadline_seconds,
                     :successful_jobs_history_limit, :failed_jobs_history_limit,
-                    :backoff_limit
+                    :job_active_deadline_seconds, :ttl_seconds_after_finished,
+                    :backoff_limit, :time_zone
 
       alias backoffLimit backoff_limit
       alias concurrencyPolicy concurrency_policy
       alias startingDeadlineSeconds starting_deadline_seconds
       alias successfulJobsHistoryLimit successful_jobs_history_limit
       alias failedJobsHistoryLimit failed_jobs_history_limit
+      alias timeZone time_zone
+      alias ttlSecondsAfterFinished ttl_seconds_after_finished
 
       def initialize(name, schedule = "* * * * *")
         super(name)
@@ -40,9 +43,12 @@ module Metatron
             startingDeadlineSeconds:,
             successfulJobsHistoryLimit:,
             failedJobsHistoryLimit:,
+            timeZone:,
             jobTemplate: {
               spec: {
-                backoffLimit:
+                activeDeadlineSeconds: job_active_deadline_seconds,
+                backoffLimit:,
+                ttlSecondsAfterFinished:
               }.merge(pod_template).compact
             }.merge(formatted_tolerations).compact
           }.compact

--- a/spec/metatron/templates/cron_job_spec.rb
+++ b/spec/metatron/templates/cron_job_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Metatron::Templates::CronJob do
       }
       cron_job.containers << container
       cron_job.active_deadline_seconds = 10
+      cron_job.job_active_deadline_seconds = 30
       cron_job.annotations = { "a.test/foo": "bar" }
       cron_job.additional_labels[:foo] = "bar"
       cron_job.backoff_limit = 5
@@ -66,6 +67,7 @@ RSpec.describe Metatron::Templates::CronJob do
       cron_job.starting_deadline_seconds = 10
       cron_job.successful_jobs_history_limit = 5
       cron_job.suspend = false
+      cron_job.ttl_seconds_after_finished = 3600
       cron_job
     end
 
@@ -88,7 +90,9 @@ RSpec.describe Metatron::Templates::CronJob do
           suspend: false,
           jobTemplate: {
             spec: {
+              activeDeadlineSeconds: 30,
               backoffLimit: 5,
+              ttlSecondsAfterFinished: 3600,
               template: {
                 metadata: { labels: { "metatron.therubyist.org/name": "hello" } },
                 spec: {


### PR DESCRIPTION
Adding support for job-level `activeDeadlineSeconds` and `ttlSecondsAfterFinished`, as well as support for `timeZone` on the cronjob spec.