### PR TITLE
feat: add name validation to Template base class

### DIFF
--- a/lib/metatron/template.rb
+++ b/lib/metatron/template.rb
@@ -38,6 +38,10 @@ module Metatron
     end
 
     def initialize(name)
+      unless name.is_a?(String) && !name.strip.empty?
+        raise ArgumentError, "name must be a non-empty string"
+      end
+
       @name = name
       @api_version = "v1"
       @kind = find_kind

--- a/spec/metatron/template_validation_spec.rb
+++ b/spec/metatron/template_validation_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Metatron::Template do
+  describe "#initialize" do
+    it "raises ArgumentError if name is nil" do
+      expect { described_class.new(nil) }.to raise_error(
+        ArgumentError, /name must be a non-empty string/
+      )
+    end
+
+    it "raises ArgumentError if name is an empty string" do
+      expect { described_class.new("") }.to raise_error(
+        ArgumentError, /name must be a non-empty string/
+      )
+    end
+
+    it "raises ArgumentError if name is only whitespace" do
+      expect { described_class.new("  ") }.to raise_error(
+        ArgumentError, /name must be a non-empty string/
+      )
+    end
+
+    it "raises ArgumentError if name is not a string" do
+      expect { described_class.new(123) }.to raise_error(
+        ArgumentError, /name must be a non-empty string/
+      )
+    end
+
+    it "works normally with a valid string name" do
+      template = described_class.new("valid-name")
+      expect(template.name).to eq("valid-name")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds input validation to the base `Metatron::Template` class — rejecting empty, nil, whitespace-only, or non-String names. This is a foundational step toward the broader template validation goal described in #15, but does not close that issue.

## Changes

### `lib/metatron/template.rb`
Added validation at the start of `Template#initialize` that raises `ArgumentError` if the name is:
- Not a `String`
- `nil`
- Empty or whitespace-only

### `spec/metatron/template_validation_spec.rb` (new, 5 examples)
- Raises `ArgumentError` for nil name
- Raises `ArgumentError` for empty string name
- Raises `ArgumentError` for whitespace-only name
- Raises `ArgumentError` for non-String name (integer)
- Accepts a valid string name without error

## Testing

```
RuboCop: clean
5 examples, 0 failures
Full suite: 168 examples, 0 failures
```

## Relation to #15

Issue #15 asks for validations that confirm templates, given appropriate data, produce output usable against the Kubernetes API. This PR adds only basic input-name validation at the base class level. Full template structure validation against Kubernetes specs remains open work tracked by #15.